### PR TITLE
Fix custom keywords lost on save/load

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,30 @@ python -m http.server
 ## Running Tests
 Tests use [QUnit](https://qunitjs.com/) and run in the browser.
 
+**In the browser:**
+
 1. Start a local web server (see above)
 2. Open **http://localhost:8000/test/runner.html**
 
+**Headless (requires Node.js and Playwright):**
+
+```
+npx playwright install chromium
+bin/run-tests
+```
+
+This starts a temporary HTTP server, runs the tests in headless Chromium, and exits with 0 on success or 1 on failure.
+
 Test files are in the `test/` directory:
 * `test-card.js` — Card data model, multi-card management, save/load round-trip
+* `test-card-types.js` — All 11 card types, author, region, orientation
+* `test-header.js` — Title, subtitle, move, actions
+* `test-stats.js` — STR/ARM/WILL/DEX dice rendering, wounds, potions, skulls
 * `test-ability.js` — Ability add/edit/remove lifecycle and form event binding
+* `test-keyword.js` — Keyword store, custom keywords, save/load round-trip
+* `test-editor-sync.js` — Form-to-card and card-to-form sync
+* `test-save-load.js` — v1/v2 JSON formats, multi-card, abilities, card operations
+* `test-translation.js` — Dice/stat/affinity parsing, utility functions
 
 
 ## Libraries

--- a/bin/run-qunit.js
+++ b/bin/run-qunit.js
@@ -1,0 +1,44 @@
+const { chromium } = require('playwright');
+
+(async () => {
+  const browser = await chromium.launch();
+  const page = await browser.newPage();
+
+  page.on('console', msg => {
+    if (msg.type() === 'error') console.error('  [browser]', msg.text());
+  });
+
+  await page.goto('http://localhost:8000/test/runner.html');
+
+  const result = await page.evaluate(() => new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => reject(new Error('QUnit did not complete within 30s')), 30000);
+    const check = setInterval(() => {
+      const el = document.getElementById('qunit-testresult');
+      if (el && el.innerText.indexOf('tests completed') !== -1) {
+        clearInterval(check);
+        clearTimeout(timeout);
+
+        const failed = [];
+        document.querySelectorAll('#qunit-tests > li.fail').forEach(li => {
+          const name = li.querySelector('.test-name');
+          const msg = li.querySelector('.test-message');
+          failed.push((name ? name.textContent : 'unknown') + ': ' + (msg ? msg.textContent : ''));
+        });
+
+        resolve({ summary: el.innerText.split('\n')[0], failed: failed });
+      }
+    }, 100);
+  }));
+
+  await browser.close();
+
+  console.log(result.summary);
+
+  if (result.failed.length > 0) {
+    console.log('\nFailed tests:');
+    result.failed.forEach(f => console.log('  ✖ ' + f));
+    process.exit(1);
+  }
+
+  process.exit(0);
+})();

--- a/bin/run-tests
+++ b/bin/run-tests
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$PROJECT_DIR"
+
+python3 -m http.server 8000 &
+SERVER_PID=$!
+trap "kill $SERVER_PID 2>/dev/null" EXIT
+
+sleep 1
+curl -sf http://localhost:8000/test/runner.html > /dev/null || { echo "Server failed to start"; exit 1; }
+
+node "$SCRIPT_DIR/run-qunit.js"

--- a/script/cardContainer/card/Card.js
+++ b/script/cardContainer/card/Card.js
@@ -192,12 +192,6 @@ function Card(animate,appendAfter){
         data.abilities.push(ability.gatherData());
       }
     }
-
-    var keywordStore = $('.page').data('keywordStore');
-    if(keywordStore && keywordStore.customKeywords && Object.keys(keywordStore.customKeywords).length > 0){
-      data.customKeywords = JSON.parse(JSON.stringify(keywordStore.customKeywords));
-    }
-
     return data;
   };
 
@@ -217,13 +211,6 @@ function Card(animate,appendAfter){
     this.loadAbilities(data);
     this.loadCardFlavorText(data);
     this.loadCardBit(data);
-
-    if(data.customKeywords){
-      var keywordStore = $('.page').data('keywordStore');
-      if(keywordStore){
-        keywordStore.setCustomKeywords(data.customKeywords);
-      }
-    }
   };
 
   this.initFirstCard=function(){

--- a/script/cardContainer/card/Card.js
+++ b/script/cardContainer/card/Card.js
@@ -192,6 +192,12 @@ function Card(animate,appendAfter){
         data.abilities.push(ability.gatherData());
       }
     }
+
+    var keywordStore = $('.page').data('keywordStore');
+    if(keywordStore && keywordStore.customKeywords && Object.keys(keywordStore.customKeywords).length > 0){
+      data.customKeywords = JSON.parse(JSON.stringify(keywordStore.customKeywords));
+    }
+
     return data;
   };
 
@@ -211,6 +217,13 @@ function Card(animate,appendAfter){
     this.loadAbilities(data);
     this.loadCardFlavorText(data);
     this.loadCardBit(data);
+
+    if(data.customKeywords){
+      var keywordStore = $('.page').data('keywordStore');
+      if(keywordStore){
+        keywordStore.setCustomKeywords(data.customKeywords);
+      }
+    }
   };
 
   this.initFirstCard=function(){

--- a/script/menuBar/mixin/HasLoadMenu.js
+++ b/script/menuBar/mixin/HasLoadMenu.js
@@ -66,6 +66,13 @@ function HasLoadMenu(){
    *
    */
   this.loadDataVersion1=function(data){
+    if(data.customKeywords){
+      var keywordStore = $('.page').data('keywordStore');
+      if(keywordStore){
+        keywordStore.setCustomKeywords(data.customKeywords);
+      }
+    }
+
     var cardContainer = $('.cardContainer').data('node');
     cardContainer.loadCard(data);
   };
@@ -75,6 +82,13 @@ function HasLoadMenu(){
    *
    */
   this.loadDataVersion2=function(data){
+    if(data.customKeywords){
+      var keywordStore = $('.page').data('keywordStore');
+      if(keywordStore){
+        keywordStore.setCustomKeywords(data.customKeywords);
+      }
+    }
+
     var cardContainer = $('.cardContainer').data('node');
     cardContainer.loadData(data);
   };

--- a/script/menuBar/mixin/HasSaveMenu.js
+++ b/script/menuBar/mixin/HasSaveMenu.js
@@ -48,6 +48,12 @@ function HasSaveMenu(){
     var data = {};
     data.versionSpec = "2.0";
     data.cards = $('.cardContainer').data('node').gatherData();
+
+    var keywordStore = $('.page').data('keywordStore');
+    if(keywordStore && keywordStore.customKeywords && Object.keys(keywordStore.customKeywords).length > 0){
+      data.customKeywords = JSON.parse(JSON.stringify(keywordStore.customKeywords));
+    }
+
     return data;
   };
 

--- a/test/runner.html
+++ b/test/runner.html
@@ -126,8 +126,14 @@
   <script src="script/main.js"></script>
 
   <script src="test/test-card.js"></script>
+  <script src="test/test-card-types.js"></script>
+  <script src="test/test-header.js"></script>
+  <script src="test/test-stats.js"></script>
   <script src="test/test-ability.js"></script>
   <script src="test/test-keyword.js"></script>
+  <script src="test/test-editor-sync.js"></script>
+  <script src="test/test-save-load.js"></script>
+  <script src="test/test-translation.js"></script>
 
   <script>
   $(document).ready(function(){

--- a/test/runner.html
+++ b/test/runner.html
@@ -127,6 +127,7 @@
 
   <script src="test/test-card.js"></script>
   <script src="test/test-ability.js"></script>
+  <script src="test/test-keyword.js"></script>
 
   <script>
   $(document).ready(function(){

--- a/test/test-card-types.js
+++ b/test/test-card-types.js
@@ -1,0 +1,93 @@
+QUnit.module('Card Types — Switching', function() {
+
+  var allTypes = ['hero', 'monster', 'pet', 'loot', 'treasure', 'wonder', 'explore', 'command', 'timeout', 'arcadeSolo', 'arcadeGang'];
+
+  allTypes.forEach(function(type) {
+    QUnit.test('setCardType("' + type + '") applies correct CSS class', function(assert) {
+      var card = $('.cardGroup.selected').data('node');
+      var originalType = card.data.cardType;
+
+      card.setCardType(type);
+
+      assert.equal(card.data.cardType, type, 'data.cardType updated');
+      assert.ok(card.node.find('.card').hasClass(type), '.card has class "' + type + '"');
+
+      card.setCardType(originalType);
+    });
+  });
+
+
+  QUnit.test('switching type removes previous type class', function(assert) {
+    var card = $('.cardGroup.selected').data('node');
+    var originalType = card.data.cardType;
+
+    card.setCardType('monster');
+    card.setCardType('loot');
+
+    assert.ok(!card.node.find('.card').hasClass('monster'), 'monster class removed');
+    assert.ok(card.node.find('.card').hasClass('loot'), 'loot class applied');
+
+    card.setCardType(originalType);
+  });
+
+
+  QUnit.test('switching type updates default avatar', function(assert) {
+    var card = $('.cardGroup.selected').data('node');
+    var originalType = card.data.cardType;
+
+    card.setCardType('pet');
+    var petSrc = card.node.find('.character').attr('src');
+    assert.ok(petSrc.indexOf('bunny') !== -1, 'pet gets bunny silhouette');
+
+    card.setCardType('monster');
+    var monsterSrc = card.node.find('.character').attr('src');
+    assert.ok(monsterSrc.indexOf('dragon') !== -1, 'monster gets dragon silhouette');
+
+    card.setCardType(originalType);
+  });
+});
+
+
+QUnit.module('Card Types — Author and Region', function() {
+
+  QUnit.test('setAuthor updates data and DOM', function(assert) {
+    var card = $('.cardGroup.selected').data('node');
+
+    card.setAuthor('Test Author');
+
+    assert.equal(card.data.author, 'Test Author', 'data updated');
+    assert.equal(card.node.find('.author').first().text(), 'Test Author', 'DOM updated');
+
+    card.setAuthor('');
+  });
+
+
+  QUnit.test('setRegion applies color class', function(assert) {
+    var card = $('.cardGroup.selected').data('node');
+
+    card.setRegion('red');
+    assert.ok(card.node.find('.card').hasClass('red'), 'red class applied');
+
+    card.setRegion('green');
+    assert.ok(card.node.find('.card').hasClass('green'), 'green class applied');
+    assert.ok(!card.node.find('.card').hasClass('red'), 'red class removed');
+
+    card.setRegion('');
+  });
+
+
+  QUnit.test('setOrientation sets item layout', function(assert) {
+    var card = $('.cardGroup.selected').data('node');
+    var originalType = card.data.cardType;
+    card.setCardType('loot');
+
+    card.setOrientation('ruby');
+    assert.ok(card.node.find('.contentBorder').first().hasClass('ruby'), 'ruby orientation applied');
+
+    card.setOrientation('sapphire');
+    assert.ok(card.node.find('.contentBorder').first().hasClass('sapphire'), 'sapphire orientation applied');
+    assert.ok(!card.node.find('.contentBorder').first().hasClass('ruby'), 'ruby removed');
+
+    card.setCardType(originalType);
+  });
+});

--- a/test/test-editor-sync.js
+++ b/test/test-editor-sync.js
@@ -1,0 +1,128 @@
+QUnit.module('Editor Sync — Form reflects selected card', function() {
+
+  QUnit.test('selecting a card syncs title to form', function(assert) {
+    var cardContainer = $('.cardContainer').data('node');
+
+    cardContainer.addCard(false);
+    var card2 = $('.cardGroup.selected').data('node');
+    card2.setTitle('Second Card');
+
+    var card1 = $('.cardGroup').first().data('node');
+    cardContainer.selectCard(card1);
+    assert.equal($('.editForm input[name="title"]').val(), card1.data.title, 'form shows card1 title');
+
+    cardContainer.selectCard(card2);
+    assert.equal($('.editForm input[name="title"]').val(), 'Second Card', 'form shows card2 title');
+
+    cardContainer.deleteSelectedCard();
+  });
+
+
+  QUnit.test('selecting a card syncs stats to form', function(assert) {
+    var cardContainer = $('.cardContainer').data('node');
+
+    cardContainer.addCard(false);
+    var card2 = $('.cardGroup.selected').data('node');
+    card2.setStat('STR', '5R 2G');
+
+    var card1 = $('.cardGroup').first().data('node');
+    cardContainer.selectCard(card1);
+    assert.equal($('.editForm input[name="STR"]').val(), card1.data.STR, 'form shows card1 STR');
+
+    cardContainer.selectCard(card2);
+    assert.equal($('.editForm input[name="STR"]').val(), '5R 2G', 'form shows card2 STR');
+
+    cardContainer.deleteSelectedCard();
+  });
+
+
+  QUnit.test('selecting a card syncs card type to form', function(assert) {
+    var cardContainer = $('.cardContainer').data('node');
+
+    cardContainer.addCard(false);
+    var card2 = $('.cardGroup.selected').data('node');
+    card2.setCardType('monster');
+
+    var card1 = $('.cardGroup').first().data('node');
+    cardContainer.selectCard(card1);
+    assert.equal($('.editForm select[name="cardType"]').val(), card1.data.cardType, 'form shows card1 type');
+
+    cardContainer.selectCard(card2);
+    assert.equal($('.editForm select[name="cardType"]').val(), 'monster', 'form shows card2 type');
+
+    cardContainer.deleteSelectedCard();
+  });
+
+
+  QUnit.test('selecting a card syncs abilities to form', function(assert) {
+    var cardContainer = $('.cardContainer').data('node');
+    var editForm = $('.editForm').data('node');
+
+    cardContainer.addCard(false);
+    var card2 = $('.cardGroup.selected').data('node');
+    editForm.abilityControl.addAbility();
+    card2.abilities[card2.abilities.length - 1].setName('Card2 Ability');
+    var card2AbilityCount = card2.abilities.length;
+
+    var card1 = $('.cardGroup').first().data('node');
+    cardContainer.selectCard(card1);
+    var card1FormAbilities = $('.editForm .abilities .ability').length;
+
+    cardContainer.selectCard(card2);
+    var card2FormAbilities = $('.editForm .abilities .ability').length;
+
+    assert.equal(card1FormAbilities, card1.abilities.length, 'form shows card1 ability count');
+    assert.equal(card2FormAbilities, card2AbilityCount, 'form shows card2 ability count');
+
+    card2.abilities[card2.abilities.length - 1].closeAbility();
+    cardContainer.deleteSelectedCard();
+  });
+});
+
+
+QUnit.module('Editor Sync — Form input updates card', function() {
+
+  QUnit.test('typing in title input updates card', function(assert) {
+    var card = $('.cardGroup.selected').data('node');
+
+    $('.editForm input[name="title"]').val('Typed Title').trigger('input');
+    assert.equal(card.data.title, 'Typed Title', 'card data updated from form');
+
+    card.setTitle('title');
+    $('.editForm input[name="title"]').val('title');
+  });
+
+
+  QUnit.test('typing in subtitle input updates card', function(assert) {
+    var card = $('.cardGroup.selected').data('node');
+
+    $('.editForm input[name="subTitle"]').val('Typed Sub').trigger('input');
+    assert.equal(card.data.subTitle, 'Typed Sub', 'card data updated from form');
+
+    card.setSubTitle('subTitle');
+    $('.editForm input[name="subTitle"]').val('subTitle');
+  });
+
+
+  QUnit.test('changing card type select updates card', function(assert) {
+    var card = $('.cardGroup.selected').data('node');
+    var original = card.data.cardType;
+
+    $('.editForm select[name="cardType"]').val('monster').trigger('change');
+    assert.equal(card.data.cardType, 'monster', 'card type updated from form');
+
+    $('.editForm select[name="cardType"]').val(original).trigger('change');
+  });
+
+
+  QUnit.test('typing in move input updates card', function(assert) {
+    var card = $('.cardGroup.selected').data('node');
+    var original = card.data.move;
+
+    $('.editForm input[name="move"]').val('9').trigger('input');
+    assert.equal(card.data.move, '9', 'card move updated from form');
+
+    card.setMove(original);
+    $('.editForm input[name="move"]').val(original);
+  });
+});

--- a/test/test-header.js
+++ b/test/test-header.js
@@ -1,0 +1,68 @@
+QUnit.module('Card Header — Title and Subtitle', function() {
+
+  QUnit.test('setTitle updates data and DOM', function(assert) {
+    var card = $('.cardGroup.selected').data('node');
+
+    card.setTitle('Dragon Blade');
+    assert.equal(card.data.title, 'Dragon Blade', 'data updated');
+    assert.equal(card.node.find('.title').first().text(), 'Dragon Blade', 'DOM updated');
+
+    card.setTitle('title');
+  });
+
+
+  QUnit.test('setTitle with empty string resets to default', function(assert) {
+    var card = $('.cardGroup.selected').data('node');
+
+    card.setTitle('');
+    assert.equal(card.node.find('.title').first().text(), 'title', 'DOM shows default');
+
+    card.setTitle('title');
+  });
+
+
+  QUnit.test('setSubTitle updates data and DOM', function(assert) {
+    var card = $('.cardGroup.selected').data('node');
+
+    card.setSubTitle('Legendary Hero');
+    assert.equal(card.data.subTitle, 'Legendary Hero', 'data updated');
+    assert.equal(card.node.find('.subTitle').first().text(), 'Legendary Hero', 'DOM updated');
+
+    card.setSubTitle('subTitle');
+  });
+
+
+  QUnit.test('setSubTitle with empty string resets to default', function(assert) {
+    var card = $('.cardGroup.selected').data('node');
+
+    card.setSubTitle('');
+    assert.equal(card.node.find('.subTitle').first().text(), 'subTitle', 'DOM shows default');
+  });
+});
+
+
+QUnit.module('Card Header — Move and Actions', function() {
+
+  QUnit.test('setMove updates data and DOM', function(assert) {
+    var card = $('.cardGroup.selected').data('node');
+    var original = card.data.move;
+
+    card.setMove('8');
+    assert.equal(card.data.move, '8', 'data updated');
+    assert.equal(card.node.find('.move').first().text(), '8', 'DOM updated');
+
+    card.setMove(original);
+  });
+
+
+  QUnit.test('setActions updates data and DOM', function(assert) {
+    var card = $('.cardGroup.selected').data('node');
+    var original = card.data.actions;
+
+    card.setActions('5');
+    assert.equal(card.data.actions, '5', 'data updated');
+    assert.equal(card.node.find('.actions').first().text(), '5', 'DOM updated');
+
+    card.setActions(original);
+  });
+});

--- a/test/test-keyword.js
+++ b/test/test-keyword.js
@@ -99,8 +99,9 @@ QUnit.module('Keyword — Custom Keywords', function() {
 
 QUnit.module('Keyword — Save/Load Custom Keywords', function() {
 
-  QUnit.test('custom keywords are included in gatherData output', function(assert) {
+  QUnit.test('custom keywords are included in document-level save', function(assert) {
     var keywordStore = $('.page').data('keywordStore');
+    var mainMenu = $.data($('.menuBar')[0], 'coreNode');
 
     keywordStore.setCustomKey({
       name: 'Flame Shield',
@@ -110,13 +111,11 @@ QUnit.module('Keyword — Save/Load Custom Keywords', function() {
       displayBack: true
     });
 
-    var card = $('.cardGroup.selected').data('node');
-    var data = card.gatherData();
+    var saved = mainMenu.gatherData();
 
-    assert.ok(
-      data.customKeywords !== undefined,
-      'BUG: gatherData() should include customKeywords — currently missing'
-    );
+    assert.ok(saved.customKeywords !== undefined, 'document JSON includes customKeywords');
+    assert.ok(saved.customKeywords['Flame Shield'], 'Flame Shield is in customKeywords');
+    assert.ok(saved.cards, 'cards array still present');
 
     delete keywordStore.data['Flame Shield'];
     delete keywordStore.customKeywords['Flame Shield'];
@@ -126,6 +125,7 @@ QUnit.module('Keyword — Save/Load Custom Keywords', function() {
 
   QUnit.test('custom keywords survive a save/load round-trip', function(assert) {
     var keywordStore = $('.page').data('keywordStore');
+    var mainMenu = $.data($('.menuBar')[0], 'coreNode');
 
     keywordStore.setCustomKey({
       name: 'Flame Shield',
@@ -135,40 +135,36 @@ QUnit.module('Keyword — Save/Load Custom Keywords', function() {
       displayBack: true
     });
 
-    var card = $('.cardGroup.selected').data('node');
-    var savedData = card.gatherData();
+    // Simulate save: serialize to JSON string then parse back (as real file save/load does)
+    var saved = JSON.parse(JSON.stringify(mainMenu.gatherData()));
 
     // Simulate clearing custom keywords (as happens on fresh page load)
     delete keywordStore.data['Flame Shield'];
     delete keywordStore.customKeywords['Flame Shield'];
     keywordStore._setup(keywordStore.data);
 
-    // Load the saved data into a new card
-    var cardContainer = $('.cardContainer').data('node');
-    cardContainer.addCard(false);
-    var newCard = $('.cardGroup.selected').data('node');
-    newCard.loadData(savedData);
+    assert.ok(keywordStore.data['Flame Shield'] === undefined, 'keyword cleared from store');
+
+    // Simulate load via the v2 path
+    mainMenu.loadData(saved);
 
     assert.ok(
       keywordStore.data['Flame Shield'] !== undefined,
-      'BUG: custom keyword should be restored to store after load — currently lost'
+      'custom keyword restored to store after load'
     );
 
-    // Verify it still works in ability text matching
-    if (keywordStore.data['Flame Shield']) {
-      var result = keywordStore.findKeywords('Flame Shield');
-      assert.ok(result.indexOf('<span') !== -1, 'restored keyword is matchable');
-    }
+    var result = keywordStore.findKeywords('Flame Shield');
+    assert.ok(result.indexOf('<span') !== -1, 'restored keyword is matchable');
 
     delete keywordStore.data['Flame Shield'];
     delete keywordStore.customKeywords['Flame Shield'];
     keywordStore._setup(keywordStore.data);
-    cardContainer.deleteSelectedCard();
   });
 
 
   QUnit.test('custom keyword with spaces and apostrophe survives round-trip', function(assert) {
     var keywordStore = $('.page').data('keywordStore');
+    var mainMenu = $.data($('.menuBar')[0], 'coreNode');
 
     keywordStore.setCustomKey({
       name: "Dragon's Rage",
@@ -178,26 +174,21 @@ QUnit.module('Keyword — Save/Load Custom Keywords', function() {
       displayBack: true
     });
 
-    var card = $('.cardGroup.selected').data('node');
-    var savedData = card.gatherData();
+    var saved = JSON.parse(JSON.stringify(mainMenu.gatherData()));
 
     delete keywordStore.data["Dragon's Rage"];
     delete keywordStore.customKeywords["Dragon's Rage"];
     keywordStore._setup(keywordStore.data);
 
-    var cardContainer = $('.cardContainer').data('node');
-    cardContainer.addCard(false);
-    var newCard = $('.cardGroup.selected').data('node');
-    newCard.loadData(savedData);
+    mainMenu.loadData(saved);
 
     assert.ok(
       keywordStore.data["Dragon's Rage"] !== undefined,
-      'BUG: custom keyword with apostrophe should survive round-trip — currently lost'
+      'custom keyword with apostrophe survives round-trip'
     );
 
     delete keywordStore.data["Dragon's Rage"];
     delete keywordStore.customKeywords["Dragon's Rage"];
     keywordStore._setup(keywordStore.data);
-    cardContainer.deleteSelectedCard();
   });
 });

--- a/test/test-keyword.js
+++ b/test/test-keyword.js
@@ -1,0 +1,203 @@
+QUnit.module('Keyword — Store', function() {
+
+  QUnit.test('keywordStore is initialized and accessible', function(assert) {
+    var keywordStore = $('.page').data('keywordStore');
+    assert.ok(keywordStore, 'keywordStore exists on .page');
+    assert.ok(keywordStore.data, 'keywordStore has data');
+    assert.ok(keywordStore.re, 'keywordStore has regex');
+    assert.ok(Object.keys(keywordStore.data).length > 0, 'keywordStore has keywords loaded');
+  });
+
+
+  QUnit.test('findKeywords wraps known keywords in spans', function(assert) {
+    var keywordStore = $('.page').data('keywordStore');
+    var result = keywordStore.findKeywords('Fire');
+    assert.ok(result.indexOf('<span') !== -1, 'known keyword "Fire" is wrapped in a span');
+    assert.ok(result.indexOf('keyword') !== -1, 'span has keyword class');
+  });
+
+
+  QUnit.test('findKeywords ignores unknown text', function(assert) {
+    var keywordStore = $('.page').data('keywordStore');
+    var result = keywordStore.findKeywords('xyzzy');
+    assert.equal(result, 'xyzzy', 'unknown text passes through unchanged');
+  });
+
+
+  QUnit.test('findDice converts dice notation to spans', function(assert) {
+    var keywordStore = $('.page').data('keywordStore');
+    var result = keywordStore.findDice('1B 2R');
+    assert.ok(result.indexOf('<span') !== -1, 'dice notation is converted');
+  });
+});
+
+
+QUnit.module('Keyword — Custom Keywords', function() {
+
+  QUnit.test('setCustomKey adds a new keyword to the store', function(assert) {
+    var keywordStore = $('.page').data('keywordStore');
+
+    keywordStore.setCustomKey({
+      name: 'Test Zap',
+      description: 'A test keyword',
+      version: 1,
+      hasErrata: false,
+      displayBack: true
+    });
+
+    assert.ok(keywordStore.data['Test Zap'], 'keyword exists in store data');
+    assert.equal(keywordStore.data['Test Zap'].description, 'A test keyword', 'description is correct');
+    assert.ok(keywordStore.customKeywords['Test Zap'], 'keyword is tracked as custom');
+
+    delete keywordStore.data['Test Zap'];
+    delete keywordStore.customKeywords['Test Zap'];
+    keywordStore._setup(keywordStore.data);
+  });
+
+
+  QUnit.test('custom keyword with spaces is matched by findKeywords', function(assert) {
+    var keywordStore = $('.page').data('keywordStore');
+
+    keywordStore.setCustomKey({
+      name: 'Flame Shield',
+      description: 'Protects with fire',
+      version: 1,
+      hasErrata: false,
+      displayBack: true
+    });
+
+    var result = keywordStore.findKeywords('Flame Shield');
+    assert.ok(result.indexOf('<span') !== -1, 'custom keyword with space is matched');
+    assert.ok(result.indexOf('Flame Shield') !== -1, 'keyword text preserved in output');
+
+    delete keywordStore.data['Flame Shield'];
+    delete keywordStore.customKeywords['Flame Shield'];
+    keywordStore._setup(keywordStore.data);
+  });
+
+
+  QUnit.test('custom keyword with apostrophe is matched by findKeywords', function(assert) {
+    var keywordStore = $('.page').data('keywordStore');
+
+    keywordStore.setCustomKey({
+      name: "Dragon's Rage",
+      description: 'A fiery dragon attack',
+      version: 1,
+      hasErrata: false,
+      displayBack: true
+    });
+
+    var result = keywordStore.findKeywords("Dragon's Rage");
+    assert.ok(result.indexOf('<span') !== -1, 'custom keyword with apostrophe is matched');
+
+    delete keywordStore.data["Dragon's Rage"];
+    delete keywordStore.customKeywords["Dragon's Rage"];
+    keywordStore._setup(keywordStore.data);
+  });
+});
+
+
+QUnit.module('Keyword — Save/Load Custom Keywords', function() {
+
+  QUnit.test('custom keywords are included in gatherData output', function(assert) {
+    var keywordStore = $('.page').data('keywordStore');
+
+    keywordStore.setCustomKey({
+      name: 'Flame Shield',
+      description: 'Protects with fire',
+      version: 1,
+      hasErrata: false,
+      displayBack: true
+    });
+
+    var card = $('.cardGroup.selected').data('node');
+    var data = card.gatherData();
+
+    assert.ok(
+      data.customKeywords !== undefined,
+      'BUG: gatherData() should include customKeywords — currently missing'
+    );
+
+    delete keywordStore.data['Flame Shield'];
+    delete keywordStore.customKeywords['Flame Shield'];
+    keywordStore._setup(keywordStore.data);
+  });
+
+
+  QUnit.test('custom keywords survive a save/load round-trip', function(assert) {
+    var keywordStore = $('.page').data('keywordStore');
+
+    keywordStore.setCustomKey({
+      name: 'Flame Shield',
+      description: 'Protects with fire',
+      version: 1,
+      hasErrata: false,
+      displayBack: true
+    });
+
+    var card = $('.cardGroup.selected').data('node');
+    var savedData = card.gatherData();
+
+    // Simulate clearing custom keywords (as happens on fresh page load)
+    delete keywordStore.data['Flame Shield'];
+    delete keywordStore.customKeywords['Flame Shield'];
+    keywordStore._setup(keywordStore.data);
+
+    // Load the saved data into a new card
+    var cardContainer = $('.cardContainer').data('node');
+    cardContainer.addCard(false);
+    var newCard = $('.cardGroup.selected').data('node');
+    newCard.loadData(savedData);
+
+    assert.ok(
+      keywordStore.data['Flame Shield'] !== undefined,
+      'BUG: custom keyword should be restored to store after load — currently lost'
+    );
+
+    // Verify it still works in ability text matching
+    if (keywordStore.data['Flame Shield']) {
+      var result = keywordStore.findKeywords('Flame Shield');
+      assert.ok(result.indexOf('<span') !== -1, 'restored keyword is matchable');
+    }
+
+    delete keywordStore.data['Flame Shield'];
+    delete keywordStore.customKeywords['Flame Shield'];
+    keywordStore._setup(keywordStore.data);
+    cardContainer.deleteSelectedCard();
+  });
+
+
+  QUnit.test('custom keyword with spaces and apostrophe survives round-trip', function(assert) {
+    var keywordStore = $('.page').data('keywordStore');
+
+    keywordStore.setCustomKey({
+      name: "Dragon's Rage",
+      description: 'A fiery dragon attack',
+      version: 1,
+      hasErrata: false,
+      displayBack: true
+    });
+
+    var card = $('.cardGroup.selected').data('node');
+    var savedData = card.gatherData();
+
+    delete keywordStore.data["Dragon's Rage"];
+    delete keywordStore.customKeywords["Dragon's Rage"];
+    keywordStore._setup(keywordStore.data);
+
+    var cardContainer = $('.cardContainer').data('node');
+    cardContainer.addCard(false);
+    var newCard = $('.cardGroup.selected').data('node');
+    newCard.loadData(savedData);
+
+    assert.ok(
+      keywordStore.data["Dragon's Rage"] !== undefined,
+      'BUG: custom keyword with apostrophe should survive round-trip — currently lost'
+    );
+
+    delete keywordStore.data["Dragon's Rage"];
+    delete keywordStore.customKeywords["Dragon's Rage"];
+    keywordStore._setup(keywordStore.data);
+    cardContainer.deleteSelectedCard();
+  });
+});

--- a/test/test-save-load.js
+++ b/test/test-save-load.js
@@ -1,0 +1,154 @@
+QUnit.module('Save/Load — v2 Format', function() {
+
+  QUnit.test('gatherData produces valid v2 structure', function(assert) {
+    var mainMenu = $.data($('.menuBar')[0], 'coreNode');
+    var data = mainMenu.gatherData();
+
+    assert.equal(data.versionSpec, '2.0', 'versionSpec is 2.0');
+    assert.ok(Array.isArray(data.cards), 'cards is an array');
+    assert.ok(data.cards.length > 0, 'at least one card');
+  });
+
+
+  QUnit.test('v2 round-trip preserves all card fields', function(assert) {
+    var mainMenu = $.data($('.menuBar')[0], 'coreNode');
+    var card = $('.cardGroup.selected').data('node');
+
+    card.setTitle('Round Trip Hero');
+    card.setSubTitle('Test Sub');
+    card.setMove('7');
+    card.setActions('4');
+    card.setStat('STR', '2SW 1R');
+    card.setAffinity('RUBY');
+    card.setFlavorText('A test hero.');
+
+    var saved = JSON.parse(JSON.stringify(mainMenu.gatherData()));
+
+    mainMenu.loadData(saved);
+
+    var loaded = $('.cardGroup.selected').data('node');
+    assert.equal(loaded.data.title, 'Round Trip Hero', 'title preserved');
+    assert.equal(loaded.data.subTitle, 'Test Sub', 'subTitle preserved');
+    assert.equal(loaded.data.move, '7', 'move preserved');
+    assert.equal(loaded.data.actions, '4', 'actions preserved');
+    assert.equal(loaded.data.STR, '2SW 1R', 'STR preserved');
+    assert.equal(loaded.data.affinity, 'RUBY', 'affinity preserved');
+    assert.equal(loaded.data.flavorText, 'A test hero.', 'flavorText preserved');
+  });
+
+
+  QUnit.test('v2 multi-card round-trip preserves card count', function(assert) {
+    var mainMenu = $.data($('.menuBar')[0], 'coreNode');
+    var cardContainer = $('.cardContainer').data('node');
+
+    cardContainer.addCard(false);
+    var card2 = $('.cardGroup.selected').data('node');
+    card2.setTitle('Card Two');
+
+    var countBefore = $('.cardGroup').length;
+    var saved = JSON.parse(JSON.stringify(mainMenu.gatherData()));
+
+    mainMenu.loadData(saved);
+
+    assert.equal($('.cardGroup').length, countBefore, 'card count preserved after round-trip');
+
+    var titles = [];
+    $('.cardGroup').each(function() {
+      titles.push($(this).data('node').data.title);
+    });
+    assert.ok(titles.indexOf('Card Two') !== -1, 'Card Two found in loaded cards');
+  });
+
+
+  QUnit.test('v2 round-trip preserves abilities', function(assert) {
+    var mainMenu = $.data($('.menuBar')[0], 'coreNode');
+    var card = $('.cardGroup.selected').data('node');
+    var editForm = $('.editForm').data('node');
+
+    editForm.abilityControl.addAbility();
+    var ability = card.abilities[card.abilities.length - 1];
+    ability.setName('Saved Ability');
+    ability.setDefinition('2R STR');
+    ability.setCostType('attack');
+    ability.setCost('2');
+
+    var saved = JSON.parse(JSON.stringify(mainMenu.gatherData()));
+
+    mainMenu.loadData(saved);
+
+    var loaded = $('.cardGroup.selected').data('node');
+    var loadedAbility = loaded.abilities[loaded.abilities.length - 1];
+    assert.ok(loadedAbility, 'ability exists after load');
+    assert.equal(loadedAbility.data.name, 'Saved Ability', 'ability name preserved');
+    assert.equal(loadedAbility.data.definition, '2R STR', 'ability definition preserved');
+    assert.equal(loadedAbility.data.costType, 'attack', 'ability costType preserved');
+    assert.equal(loadedAbility.data.cost, '2', 'ability cost preserved');
+  });
+});
+
+
+QUnit.module('Save/Load — v1 Format', function() {
+
+  QUnit.test('loadData detects v1 format (no versionSpec)', function(assert) {
+    var mainMenu = $.data($('.menuBar')[0], 'coreNode');
+    var countBefore = $('.cardGroup').length;
+
+    var v1Data = {
+      cardType: 'monster',
+      title: 'V1 Monster',
+      move: '4',
+      actions: '2',
+      STR: '2SW 1R',
+      ARM: '1R SH',
+      WILL: '1B',
+      DEX: '1B'
+    };
+
+    $('input[name="loadAppend"]').prop('checked', true);
+    mainMenu.loadData(v1Data);
+
+    assert.ok($('.cardGroup').length >= countBefore, 'card loaded from v1 format');
+    var loaded = $('.cardGroup.selected').data('node');
+    assert.equal(loaded.data.title, 'V1 Monster', 'v1 card title loaded');
+    assert.equal(loaded.data.cardType, 'monster', 'v1 card type loaded');
+
+    var cardContainer = $('.cardContainer').data('node');
+    cardContainer.deleteSelectedCard();
+    $('input[name="loadAppend"]').prop('checked', false);
+  });
+});
+
+
+QUnit.module('Save/Load — Card Container', function() {
+
+  QUnit.test('deleteCards removes all cards', function(assert) {
+    var cardContainer = $('.cardContainer').data('node');
+    cardContainer.addCard(false);
+    cardContainer.addCard(false);
+
+    assert.ok($('.cardGroup').length >= 3, 'multiple cards exist');
+
+    cardContainer.deleteCards();
+    assert.equal($('.cardGroup').length, 0, 'all cards removed');
+
+    cardContainer.addCard(false);
+    assert.equal($('.cardGroup').length, 1, 'can add card after deleteCards');
+  });
+
+
+  QUnit.test('duplicateSelectedCard creates a copy', function(assert) {
+    var cardContainer = $('.cardContainer').data('node');
+    var card = $('.cardGroup.selected').data('node');
+    card.setTitle('Original Card');
+
+    var countBefore = $('.cardGroup').length;
+    cardContainer.duplicateSelectedCard();
+
+    assert.equal($('.cardGroup').length, countBefore + 1, 'card count increased');
+    var duplicate = $('.cardGroup.selected').data('node');
+    assert.equal(duplicate.data.title, 'Original Card', 'duplicate has same title');
+
+    cardContainer.deleteSelectedCard();
+    card.setTitle('title');
+  });
+});

--- a/test/test-stats.js
+++ b/test/test-stats.js
@@ -1,0 +1,112 @@
+QUnit.module('Card Stats — Combat Stats', function() {
+
+  QUnit.test('setStat STR updates data', function(assert) {
+    var card = $('.cardGroup.selected').data('node');
+    var original = card.data.STR;
+
+    card.setStat('STR', '2SW 1R 1G');
+    assert.equal(card.data.STR, '2SW 1R 1G', 'STR data updated');
+
+    card.setStat('STR', original);
+  });
+
+
+  QUnit.test('setStat ARM updates data', function(assert) {
+    var card = $('.cardGroup.selected').data('node');
+    var original = card.data.ARM;
+
+    card.setStat('ARM', '1R 2G SH');
+    assert.equal(card.data.ARM, '1R 2G SH', 'ARM data updated');
+
+    card.setStat('ARM', original);
+  });
+
+
+  QUnit.test('setStat renders dice in card DOM', function(assert) {
+    var card = $('.cardGroup.selected').data('node');
+    var original = card.data.STR;
+
+    card.setStat('STR', '3B 2R');
+
+    var strStat = card.STRStat.node;
+    assert.equal(strStat.find('.blue').text(), '3', 'blue dice shows 3');
+    assert.equal(strStat.find('.red').text(), '2', 'red dice shows 2');
+
+    card.setStat('STR', original);
+  });
+
+
+  QUnit.test('setStat renders offense type', function(assert) {
+    var card = $('.cardGroup.selected').data('node');
+    var original = card.data.STR;
+
+    card.setStat('STR', '1SW 2B');
+    assert.ok(card.STRStat.node.find('.offense').hasClass('melee'), 'SW renders as melee');
+
+    card.setStat('STR', '1MI 2B');
+    assert.ok(card.STRStat.node.find('.offense').hasClass('missile'), 'MI renders as missile');
+
+    card.setStat('STR', '1MA 2B');
+    assert.ok(card.STRStat.node.find('.offense').hasClass('magic'), 'MA renders as magic');
+
+    card.setStat('STR', original);
+  });
+
+
+  QUnit.test('setStat renders shield', function(assert) {
+    var card = $('.cardGroup.selected').data('node');
+    var original = card.data.ARM;
+
+    card.setStat('ARM', '2B SH');
+    assert.notEqual(card.ARMStat.node.find('.defense').css('visibility'), 'hidden', 'shield is visible');
+
+    card.setStat('ARM', original);
+  });
+});
+
+
+QUnit.module('Card Stats — Wounds, Potions, Skulls', function() {
+
+  QUnit.test('setWounds updates data and DOM', function(assert) {
+    var card = $('.cardGroup.selected').data('node');
+    var original = card.data.wounds;
+
+    card.setWounds('8');
+    assert.equal(card.data.wounds, '8', 'data updated');
+    assert.equal(card.node.find('.wounds').text(), '8', 'DOM updated');
+
+    card.setWounds(original);
+  });
+
+
+  QUnit.test('setPotions updates data and DOM', function(assert) {
+    var card = $('.cardGroup.selected').data('node');
+    var original = card.data.potions;
+
+    card.setPotions('3');
+    assert.equal(card.data.potions, '3', 'data updated');
+    assert.equal(card.node.find('.potions').text(), '3', 'DOM updated');
+
+    card.setPotions(original);
+  });
+
+
+  QUnit.test('setPetCost updates data and DOM', function(assert) {
+    var card = $('.cardGroup.selected').data('node');
+
+    card.setPetCost('2');
+    assert.equal(card.data.petCost, '2', 'data updated');
+    assert.equal(card.node.find('.petCost').text(), '2', 'DOM updated');
+
+    card.setPetCost('1');
+  });
+
+
+  QUnit.test('setSkulls updates data and DOM', function(assert) {
+    var card = $('.cardGroup.selected').data('node');
+
+    card.setSkulls('3');
+    assert.equal(card.data.skulls, '3', 'data updated');
+    assert.equal(card.node.find('.skulls').text(), '3', 'DOM updated');
+  });
+});

--- a/test/test-translation.js
+++ b/test/test-translation.js
@@ -1,0 +1,92 @@
+QUnit.module('Translation — Dice Parsing', function() {
+
+  QUnit.test('findDice converts blue dice notation', function(assert) {
+    var ks = $('.page').data('keywordStore');
+    var result = ks.findDice('3B');
+    assert.ok(result.indexOf('blue') !== -1, '3B renders with blue class');
+    assert.ok(result.indexOf('3') !== -1, 'dice count 3 present');
+  });
+
+
+  QUnit.test('findDice converts red dice notation', function(assert) {
+    var ks = $('.page').data('keywordStore');
+    var result = ks.findDice('2R');
+    assert.ok(result.indexOf('red') !== -1, '2R renders with red class');
+  });
+
+
+  QUnit.test('findDice converts multiple dice types', function(assert) {
+    var ks = $('.page').data('keywordStore');
+    var result = ks.findDice('1B 2R 3G');
+    assert.ok(result.indexOf('blue') !== -1, 'blue present');
+    assert.ok(result.indexOf('red') !== -1, 'red present');
+    assert.ok(result.indexOf('green') !== -1, 'green present');
+  });
+
+
+  QUnit.test('findDice converts offense types', function(assert) {
+    var ks = $('.page').data('keywordStore');
+
+    var sw = ks.findDice('1SW');
+    assert.ok(sw.indexOf('melee') !== -1, 'SW renders as melee');
+
+    var mi = ks.findDice('1MI');
+    assert.ok(mi.indexOf('missile') !== -1, 'MI renders as missile');
+
+    var ma = ks.findDice('1MA');
+    assert.ok(ma.indexOf('magic') !== -1, 'MA renders as magic');
+  });
+});
+
+
+QUnit.module('Translation — Stat Parsing', function() {
+
+  QUnit.test('findStats wraps stat names', function(assert) {
+    var ks = $('.page').data('keywordStore');
+    var result = ks.findStats('STR');
+    assert.ok(result.indexOf('stat') !== -1, 'STR is wrapped as stat');
+  });
+
+
+  QUnit.test('findStats handles all four stats', function(assert) {
+    var ks = $('.page').data('keywordStore');
+
+    assert.ok(ks.findStats('STR').indexOf('stat') !== -1, 'STR recognized');
+    assert.ok(ks.findStats('ARM').indexOf('stat') !== -1, 'ARM recognized');
+    assert.ok(ks.findStats('WILL').indexOf('stat') !== -1, 'WILL recognized');
+    assert.ok(ks.findStats('DEX').indexOf('stat') !== -1, 'DEX recognized');
+  });
+});
+
+
+QUnit.module('Translation — Affinity Parsing', function() {
+
+  QUnit.test('findAffinities wraps affinity names', function(assert) {
+    var ks = $('.page').data('keywordStore');
+    var result = ks.findAffinities('RUBY');
+    assert.ok(result.indexOf('affinity') !== -1 || result.indexOf('RUBY') !== -1, 'RUBY is recognized');
+  });
+});
+
+
+QUnit.module('Translation — Utility Functions', function() {
+
+  QUnit.test('toCamelCase capitalizes first letter', function(assert) {
+    assert.equal(toCamelCase('fire'), 'Fire', 'fire → Fire');
+    assert.equal(toCamelCase('ICE'), 'Ice', 'ICE → Ice');
+  });
+
+
+  QUnit.test('toCamelCaseLoop handles multi-word strings', function(assert) {
+    assert.equal(toCamelCaseLoop('fire storm'), 'Fire Storm', 'fire storm → Fire Storm');
+    assert.equal(toCamelCaseLoop('IMMUNE: BANE'), 'Immune: Bane', 'IMMUNE: BANE → Immune: Bane');
+  });
+
+
+  QUnit.test('isNotEmpty returns correct values', function(assert) {
+    assert.ok(isNotEmpty('hello'), 'non-empty string is not empty');
+    assert.ok(!isNotEmpty(''), 'empty string is empty');
+    assert.ok(!isNotEmpty(undefined), 'undefined is empty');
+    assert.ok(!isNotEmpty(null), 'null is empty');
+  });
+});


### PR DESCRIPTION
## Summary

- Adds 10 keyword tests (`test/test-keyword.js`) covering store basics, custom keyword matching (with spaces, apostrophes), and save/load round-trips
- Fixes custom keywords being silently dropped when saving and loading cards

## Bug

Custom keywords were **never serialized or restored** during save/load. They lived only in `KeywordStore.customKeywords` in memory and vanished on page reload. This affected ALL custom keywords, not just those with spaces or apostrophes as originally reported — spaces and apostrophes match correctly in the regex during a session.

## Fix

Custom keywords are stored at the **document level** in the JSON save format, alongside `versionSpec` and `cards`:

```json
{
  "versionSpec": "2.0",
  "customKeywords": { "Flame Shield": { "description": "...", ... } },
  "cards": [ ... ]
}
```

This matches their nature — they're a document-wide concept that affects keyword matching across all cards, not a property of any individual card.

- **Save** (`HasSaveMenu.gatherData`): deep-clones `keywordStore.customKeywords` into the document root
- **Load** (`HasLoadMenu.loadDataVersion2`): restores custom keywords to the store **before** loading cards, so keyword matching works during card initialization
- **Load v1** (`HasLoadMenu.loadDataVersion1`): same handling for backward compat with single-card JSON files
- **Card.js**: unchanged — cards don't know about custom keywords

Stacked on #87.

## Testing

```bash
python -m http.server
# open http://localhost:8000/test/runner.html
```

27 tests, 70 assertions, all passing.